### PR TITLE
[fix] buffer overflow at realpath()

### DIFF
--- a/sfm.c
+++ b/sfm.c
@@ -33,7 +33,7 @@
 #include "util.h"
 
 /* macros */
-#define MAX_P 4095
+#define MAX_P 4096
 #define MAX_N 255
 #define MAX_USRI 32
 #define MAX_EXT 4


### PR DESCRIPTION
Trying to run sfm, I got it crashed at startup with:
```
*** buffer overflow detected ***: terminated
fish: 'sfm' terminated by signal SIGABRT (Abort)
```
Backtrace shows:
```
(gdb) bt
#0  0x00007fcdf407e33a in raise () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6build -A sfmix-build -A sfmx-build -Anix-#1  0x00007fcdf4068523 in abort () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6ur-packages (master)>
#2  0x00007fcdf40be958 in __libc_message () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#3  0x00007fcdf414c2c2 in __fortify_fail () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#4  0x00007fcdf414ad80 in __chk_fail () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#5  0x00007fcdf414b2b4 in __realpath_chk () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#6  0x0000000000403315 in ?? ()
#7  0x0000000000403f78 in ?? ()
#8  0x0000000000404804 in ?? ()
#9  0x00000000004025d1 in ?? ()
#10 0x00007fcdf4069ded in __libc_start_main () from /nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6
#11 0x00000000004027da in ?? ()
```
Root cause is here:
https://github.com/afify/sfm/blob/aa11844d533c54488a96c7a32a7eb5c19a9b5663/sfm.c#L283

[realpath](https://linux.die.net/man/3/realpath) man page says:
> The resulting pathname is stored as a null-terminated string, up to a maximum of PATH_MAX bytes, in the buffer pointed to by resolved_path.

`PATH_MAX` defined in `linux/limits.h` as:
> #define PATH_MAX        4096    /* # chars in a path name including nul */

But in sfm we use buffer size of 4095:
https://github.com/afify/sfm/blob/aa11844d533c54488a96c7a32a7eb5c19a9b5663/sfm.c#L36
https://github.com/afify/sfm/blob/aa11844d533c54488a96c7a32a7eb5c19a9b5663/sfm.c#L273

Changing it to 4096 solves the issue.