### PR TITLE
Autodetect macOS and include the necessary _DARWIN_C_SOURCE

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -7,6 +7,11 @@ MANPREFIX = ${PREFIX}/share/man
 
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DVERSION=\"${VERSION}\"
+
+ifeq ($(shell uname -s),Darwin)
+CPPFLAGS += -D_DARWIN_C_SOURCE
+endif
+
 CFLAGS   = -std=c99 -pedantic -Wextra -Wall -Os ${CPPFLAGS}
 LDFLAGS  = -s
 


### PR DESCRIPTION
macOS requires `_DARWIN_C_SOURCE` to be defined for build. I noticed at a [dvtm issue](https://github.com/martanne/dvtm/issues/43) this is to be included (in sfm's case) in CPPFLAGS, but doesn't need to be on every OS. However, I believe they decided to let the package maintainers deal with it in patches for their package system.

I am unsure if you want to do that or not, so I added some basic OS detection and put it in the appropriate CPPFLAGS section in `config.mk`. You may want to lean on their decision on *maybe not* including it, or update the README.md for macOS users to do,

    $ CPPFLAGS=-D_DARWIN_C_SOURCE make
    $ make install

But that still requires an update to `config.mk` to include

    diff --git a/config.mk b/config.mk
    index 8b632c6..976a903 100644
    --- a/config.mk
    +++ b/config.mk
    @@ -6,7 +6,7 @@ PREFIX    = /usr/local
     MANPREFIX = ${PREFIX}/share/man

     # flags
    -CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DVERSION=\"${VERSION}\"
    +CPPFLAGS += -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DVERSION=\"${VERSION}\"
     CFLAGS   = -std=c99 -pedantic -Wextra -Wall -Os ${CPPFLAGS}
     LDFLAGS  = -s

because `CPPFLAGS+=... make` or `CPPFLAGS=... make` doesn't work unless that `+` is added in the config.mk file.

I think it is up to you if you want to go the suckless route and keep the makefile minimal, or add my patch in for convenience of users. But adding the `+` to config.mk and edit the README.md is not a big deal and stays minimal with the suckless philosophy. 

If you want you can reject this pull and I can submit a new one with the README.md and config.mk updated accordingly.