### PR TITLE
Added preprocessor definitions for Linux and Apple req. for SIGWINCH

### DIFF
--- a/termbox.c
+++ b/termbox.c
@@ -1,3 +1,8 @@
+#if defined (__linux__)
+#define _GNU_SOURCE
+#elif defined (__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Here is the proper fix for _DARWIN_C_SOURCE. You were right @afify, it was my bad. I wasn't putting the Preprocessor definitions at the top of the file. This now compiles and doesn't touch the the config.mk.