### PR TITLE
add linux/macOS preprocossor defines for signals

### DIFF
--- a/sfm.c
+++ b/sfm.c
@@ -2,6 +2,8 @@
 
 #if defined(__linux__)
 #define _GNU_SOURCE
+#elif defined(__APPLE__)
+#define _DARWIN_C_SOURCE
 #endif
 #include <sys/types.h>
 #include <sys/resource.h>

--- a/termbox.c
+++ b/termbox.c
@@ -1,3 +1,8 @@
+#if defined (__linux__)
+#define _GNU_SOURCE
+#elif defined (__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
As requested, updated e-mail and changed header to be <50 characters.

The preprocessor definition `_DARWIN_C_SOURCE` is required for SIGWINCH definitions on macOS defined in termbox.c.