### PR TITLE
[fix] correct update_screen selected entry render behaviour

### DIFF
--- a/sfm.c
+++ b/sfm.c
@@ -447,7 +447,7 @@ append_entries(Pane *pane)
 		entry = pane->entries[pane->start_index + i];
 
 		/* selected entry */
-		if (pane->entries[i].selected == 1)
+		if (entry.selected == 1)
 			entry.color = color_selected;
 
 		/* current entry */


### PR DESCRIPTION
I found a bug that caused the erroneous rendering of selected in visual mode by the `update_screen` function.

When the user selects some files in visual mode, the marking of files within the first pane length (from 0 up to `term.rows`) is always rendered at their first pane position when the user calls `update_screen`.  If the user selects file entries beyond the first pane length, then `update_screen` never or derenders them.

Fortunately, it is easy to fix.